### PR TITLE
PLAT-7348: build custom 1.32 AMI with docker

### DIFF
--- a/templates/al2/variables-1.32.json
+++ b/templates/al2/variables-1.32.json
@@ -1,0 +1,6 @@
+{
+    "ami_component_description": "(k8s: {{ user `kubernetes_version` }}, docker: {{ user `docker_version` }}, containerd: {{ user `containerd_version` }})",
+    "install_docker": "true",
+    "docker_version": "25.0.*",
+    "aws_region": "us-east-2"
+}


### PR DESCRIPTION
In preparation for the EKS 1.32 upgrade.
AMI already built and pushed
https://bokucorp.atlassian.net/browse/PLAT-7348